### PR TITLE
Reflect last go recommendation for installing package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A command to convert Gherkin files into Markdown.
 ## Installation
 
 ```
-go get -u github.com/raviqqe/gherkin2markdown
+go install github.com/raviqqe/gherkin2markdown@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Hello
While using the project for the first time. I noticed this.
Existing command produce

```
 go get -u github.com/raviqqe/gherkin2markdown
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```