### PR TITLE
Move convert functions into an importable package

### DIFF
--- a/arguments.go
+++ b/arguments.go
@@ -13,12 +13,14 @@ Usage:
 Options:
 	-h, --help  Show this help.`
 
+// Arguments is the available CLI arguments.
 type Arguments struct {
 	File    string `docopt:"<file>"`
 	SrcDir  string `docopt:"<srcdir>"`
 	DestDir string `docopt:"<destdir>"`
 }
 
+// GetArguments return the CLI arguments.
 func GetArguments(ss []string) (Arguments, error) {
 	args := Arguments{}
 	err := parseArguments(usage, ss, &args)

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -14,7 +14,9 @@ import (
 
 const featureFileExtension = ".feature"
 
-func ConvertFile(s string, w io.Writer) error {
+// FeatureFile converts a single feature file at the given path and writes the
+// result to an [io.Writer].
+func FeatureFile(s string, w io.Writer) error {
 	f, err := os.Open(s)
 
 	if err != nil {
@@ -27,11 +29,14 @@ func ConvertFile(s string, w io.Writer) error {
 		return err
 	}
 
-	_, err = fmt.Fprint(w, renderer.NewRenderer().Render(d))
+	_, err = fmt.Fprint(w, renderer.New().Render(d))
 	return err
 }
 
-func ConvertFiles(s, d string) error {
+// FeatureFiles converts all feature files under the given directory and
+// writes each result to a markdown file of the same base name (with .feature
+// suffix removed and .md added).
+func FeatureFiles(s, d string) error {
 	ps := []string{}
 
 	err := filepath.Walk(s, func(p string, i os.FileInfo, err error) error {
@@ -66,7 +71,7 @@ func ConvertFiles(s, d string) error {
 				return
 			}
 
-			err = ConvertFile(p, f)
+			err = FeatureFile(p, f)
 
 			if err != nil {
 				es <- err

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/raviqqe/gherkin2markdown/convert"
 )
 
-func TestConvertFile(t *testing.T) {
+func TestFeatureFile(t *testing.T) {
 	f, err := os.CreateTemp("", "")
 	assert.Nil(t, err)
 	defer func() { assert.Nil(t, os.Remove(f.Name())) }()
@@ -16,10 +18,10 @@ func TestConvertFile(t *testing.T) {
 	_, err = f.Write([]byte("Feature: Foo"))
 	assert.Nil(t, err)
 
-	assert.Nil(t, main.ConvertFile(f.Name(), io.Discard))
+	assert.Nil(t, convert.FeatureFile(f.Name(), io.Discard))
 }
 
-func TestConvertFileError(t *testing.T) {
+func TestFeatureFileError(t *testing.T) {
 	f, err := os.CreateTemp("", "")
 	assert.Nil(t, err)
 	defer func() { assert.Nil(t, os.Remove(f.Name())) }()
@@ -27,13 +29,13 @@ func TestConvertFileError(t *testing.T) {
 	_, err = f.Write([]byte("Feature"))
 	assert.Nil(t, err)
 
-	assert.NotNil(t, main.ConvertFile(f.Name(), io.Discard))
+	assert.NotNil(t, convert.FeatureFile(f.Name(), io.Discard))
 }
 
-func TestConvertFilesWithNonReadableSourceDir(t *testing.T) {
+func TestFeatureFilesWithNonReadableSourceDir(t *testing.T) {
 	d, err := os.MkdirTemp("", "")
 	assert.Nil(t, err)
 	defer func() { assert.Nil(t, os.RemoveAll(d)) }()
 
-	assert.NotNil(t, main.ConvertFiles("foo", d))
+	assert.NotNil(t, convert.FeatureFiles("foo", d))
 }

--- a/main.go
+++ b/main.go
@@ -18,14 +18,15 @@ func main() {
 	}
 }
 
+// Run executes the CLI command.
 func Run(ss []string, w io.Writer) error {
 	args, err := GetArguments(ss)
 
 	if err != nil {
 		return err
 	} else if args.File == "" {
-		return convert.ConvertFiles(args.SrcDir, args.DestDir)
+		return convert.FeatureFiles(args.SrcDir, args.DestDir)
 	}
 
-	return convert.ConvertFile(args.File, w)
+	return convert.FeatureFile(args.File, w)
 }

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -7,15 +7,25 @@ import (
 	"github.com/willf/pad/utf8"
 )
 
+// Renderer represents various parts of a Cucumber document as Markdown
+// strings.
+type Renderer interface {
+	// Render returns a Markdown string for the given
+	// [*messages.GherkinDocument].
+	Render(d *messages.GherkinDocument) string
+}
+
 type renderer struct {
 	*strings.Builder
 	depth int
 }
 
-func NewRenderer() *renderer {
+// New returns a new [Renderer].
+func New() Renderer {
 	return &renderer{&strings.Builder{}, 0}
 }
 
+// Render returns a Markdown string for the given [*messages.GherkinDocument].
 func (r *renderer) Render(d *messages.GherkinDocument) string {
 	r.renderFeature(d.Feature)
 

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -7,10 +7,12 @@ import (
 
 	gherkin "github.com/cucumber/gherkin/go/v27"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/raviqqe/gherkin2markdown/renderer"
 )
 
-func TestNewRenderer(t *testing.T) {
-	main.NewRenderer()
+func TestNew(t *testing.T) {
+	renderer.New()
 }
 
 func TestRendererRender(t *testing.T) {
@@ -214,6 +216,6 @@ _When_ qux.
 		d, err := gherkin.ParseGherkinDocument(strings.NewReader(ss[0]), func() string { return "" })
 
 		assert.Nil(t, err)
-		assert.Equal(t, strings.TrimSpace(ss[1])+"\n", main.NewRenderer().Render(d))
+		assert.Equal(t, strings.TrimSpace(ss[1])+"\n", renderer.New().Render(d))
 	}
 }


### PR DESCRIPTION
The convert functions are useful for downstream use. Move them into an importable package.