### PR TITLE
Fix markdown for data tables

### DIFF
--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cucumber/gherkin/go/v28"
+	gherkin "github.com/cucumber/gherkin/go/v28"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/raviqqe/gherkin2markdown/renderer"
@@ -95,8 +95,27 @@ Feature: Foo
 
 _Given_ Baz:
 
+|     |
+|-----|
 | foo |
 | bar |`,
+		},
+		{`
+Feature: Foo
+  Background: Bar
+  Given Baz:
+    | foo | baz |
+    | bar | qux |`, `
+# Foo
+
+## Background (Bar)
+
+_Given_ Baz:
+
+|     |     |
+|-----|-----|
+| foo | baz |
+| bar | qux |`,
 		},
 		{`
 Feature: Foo


### PR DESCRIPTION
Gherkin data tables can take a multitude of forms: simple lists or represent tabular data with no headers or headers along either axis (or both), while most markdown implementations only support tables with a header row. Omitting the header leads to markdown that cannot be fully converted to HTML.

Work around this incongruity by rendering all data tables as markdown tables with an empty header.

Fixes #66